### PR TITLE
Read the output-file for each invocation of the reporter.

### DIFF
--- a/lib/bamboo.js
+++ b/lib/bamboo.js
@@ -1,8 +1,7 @@
 var Base = require('mocha').reporters.Base
   , cursor = Base.cursor
   , color = Base.color
-  , fs = require('fs')
-  , filename = process.env.MOCHA_FILE || 'mocha.json';
+  , fs = require('fs');
 
 exports = module.exports = BambooJSONReporter;
 
@@ -14,7 +13,8 @@ exports = module.exports = BambooJSONReporter;
  */
 
 function BambooJSONReporter(runner) {
-  var self = this;
+  var self = this
+    , filename = process.env.MOCHA_FILE || 'mocha.json';
   Base.call(this, runner);
 
   var tests = []
@@ -29,7 +29,7 @@ function BambooJSONReporter(runner) {
   runner.on('pending', function(test) {
     skipped.push(test);
   });
-  
+
   runner.on('pass', function(test){
     passes.push(test);
   });
@@ -50,7 +50,7 @@ function BambooJSONReporter(runner) {
   });
   runner.on('start', function() {
     if (fs.existsSync(filename)) {
-      fs.unlinkSync(filename); // if we die at some point, we don't want bamboo to have a stale results file lying around...      
+      fs.unlinkSync(filename); // if we die at some point, we don't want bamboo to have a stale results file lying around...
     }
   });
 }


### PR DESCRIPTION
To allow multiple output-files.

Code sample for use-case

```javascript
function runTests(tests) {
    var mocha = require('gulp-mocha');

    var reporter = require('mocha-bamboo-reporter');

    return gulp
        .src(tests, { read: false })
        .pipe(mocha({ reporter: reporter }))
        .on('error', function (err) {
            gutil.log(err);

            this.emit('end');
        });
}

gulp.task('test:bamboo:unit', function () {
    process.env.MOCHA_FILE = 'tests-unit.json';

    return runTests(paths.tests.unit);
});

gulp.task('test:bamboo:e2e', function () {
    process.env.MOCHA_FILE = 'tests-e2e.json';

    return runTests(paths.tests.e2e);
});
```
