### PR TITLE
Recieve an reporterOptions object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ logs
 results
 
 npm-debug.log
+
+node_modules/

--- a/lib/bamboo.js
+++ b/lib/bamboo.js
@@ -1,8 +1,7 @@
 var Base = require('mocha').reporters.Base
   , cursor = Base.cursor
   , color = Base.color
-  , fs = require('fs')
-  , filename = process.env.MOCHA_FILE || 'mocha.json';
+  , fs = require('fs');
 
 exports = module.exports = BambooJSONReporter;
 
@@ -13,8 +12,12 @@ exports = module.exports = BambooJSONReporter;
  * @api public
  */
 
-function BambooJSONReporter(runner) {
-  var self = this;
+function BambooJSONReporter(runner, options) {
+  options.reporterOptions = options.reporterOptions || {};
+
+  var self = this
+    , filename = options.reporterOptions.outputFile || process.env.MOCHA_FILE || 'mocha.json';
+
   Base.call(this, runner);
 
   var tests = []
@@ -29,7 +32,7 @@ function BambooJSONReporter(runner) {
   runner.on('pending', function(test) {
     skipped.push(test);
   });
-  
+
   runner.on('pass', function(test){
     passes.push(test);
   });
@@ -50,7 +53,7 @@ function BambooJSONReporter(runner) {
   });
   runner.on('start', function() {
     if (fs.existsSync(filename)) {
-      fs.unlinkSync(filename); // if we die at some point, we don't want bamboo to have a stale results file lying around...      
+      fs.unlinkSync(filename); // if we die at some point, we don't want bamboo to have a stale results file lying around...
     }
   });
 }


### PR DESCRIPTION
This is an alternative to #7 

Bamboo remains the same, usage code is then:

```javascript
function runTests(tests, outputFile) {
    var mocha = require('gulp-mocha');

    var reporter = require('mocha-bamboo-reporter');

    return gulp.src(tests, { read: false })
        .pipe(mocha({
            reporter: reporter,
            reporterOptions: {
                outputFile: outputFile
            }
        }))
        .on('error', function (err) {
            gutil.log(err);

            this.emit('end');
        });
}

gulp.task('test:bamboo:unit', function () {
    return runTests(paths.tests.unit, 'tests-unit.json');
});

gulp.task('test:bamboo:e2e', function () {
    return runTests(paths.tests.e2e, 'tests-e2e.json');
});
```

The environment variable is kept for compatibility, I also haven't tested this outside of gulp. Can you send arbitrary options to mocha during CLI invocation?

