### PR TITLE
Use error message if stack does not exist

### DIFF
--- a/lib/bamboo.js
+++ b/lib/bamboo.js
@@ -74,9 +74,14 @@ function clean(test) {
       title: test.title
     , fullTitle: test.fullTitle()
     , duration: test.duration
-  }
+  };
   if (test.hasOwnProperty("err")) {
-    o.error = test.err.stack.toString();
+    if (test.err.stack) {
+      o.error = test.err.stack.toString();
+    }
+    else if (test.err.message) {
+      o.error = test.err.message;
+    }
   }
   return o;
 }


### PR DESCRIPTION
Some runners might not set a stack (such as [mocha-jshint](https://github.com/ebdrup/mocha-jshint)), therefore use a supplied message if it's available.

Also satisfies pull request #5.