### PR TITLE
Set mocha as a peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "directories": {
     "lib": "./lib"
   },
-  "dependencies": {
+  "peerDependencies": {
     "mocha": ">=1.8.1"
   }
 }


### PR DESCRIPTION
It has several benefits:
- the parent project decides the version of mocha to use;
- it reduces the number of installed packages;
- better security as older mocha versions have critical security bugs.

I did not change the version of mocha declared, since it matters less now. But it remains useful as a way to declare which versions of mocha are supported.