### PR TITLE
add option for using the spec reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,16 @@ To run your Mocha tests without modifying your package.json you can simply do th
 
 * Add a "npm" task with command `install mocha-bamboo-reporter`
 * Add a "Node.js" task with script `node_modules/mocha/bin/mocha` and arguments `--reporter mocha-bamboo-reporter`, along with any other arguments you want to pass to Mocha
-* To overwrite default output to mocha.json in current directory, add option `--reporter-options output=/path/to/output.json`
 * You'll still need to run a "Parse mocha results" task, and ensure you don't use an old mocha.json
+
+### Options
+
+If you want to use more options, combine them with a comma: `--reporter-options output=/path/to/output.json,spec=true`
+
+#### File path
+
+To overwrite the default output as mocha.json in current directory, add option `--reporter-options output=/path/to/output.json`
+
+#### Console output
+
+If you want to keep Mocha's default behavior of printing test results to the standard output using the spec reporter, add option `--reporter-options spec=true`

--- a/lib/bamboo.js
+++ b/lib/bamboo.js
@@ -1,9 +1,10 @@
 var Base = require('mocha').reporters.Base
-  , cursor = Base.cursor
-  , color = Base.color
+  , Spec = require('mocha').reporters.Spec
   , fs = require('fs')
+  , inherits = require('util').inherits
   , filename = process.env.MOCHA_FILE || 'mocha.json';
 
+inherits(BambooJSONReporter, Base);
 exports = module.exports = BambooJSONReporter;
 
 /**
@@ -16,7 +17,12 @@ exports = module.exports = BambooJSONReporter;
 
 function BambooJSONReporter(runner, options) {
   var self = this;
-  Base.call(this, runner);
+  if (options && options.reporterOptions && options.reporterOptions.spec) {
+    Spec.call(this, runner);
+  }
+  else {
+    Base.call(this, runner);
+  }
 
   var tests = []
     , failures = []


### PR DESCRIPTION
It always bothered me that the bamboo reporter doesn't output to the console.
The log file is the first place I go to when my test fails, so with this pull request it's possible to use the spec reporter instead of the base via an option.
I've also removed the unused cursor and color imports.