### PR TITLE
Generate unique output file based on test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ logs
 results
 
 npm-debug.log
+node_modules

--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ To run your Mocha tests without modifying your package.json you can simply do th
 * Add a "Node.js" task with script `node_modules/mocha/bin/mocha` and arguments `--reporter mocha-bamboo-reporter`, along with any other arguments you want to pass to Mocha
 * To overwrite default output to mocha.json in current directory, add option `--reporter-options output=/path/to/output.json`
 * You'll still need to run a "Parse mocha results" task, and ensure you don't use an old mocha.json
+
+### Mocha Options
+
+* `output` - Specfies the output path of the test results.  To generate a unique file per test result, you can include `[hash]` in the path, which will be replaced by a hash of the output, e.g. `mocha-[hash].json`
+

--- a/lib/bamboo.js
+++ b/lib/bamboo.js
@@ -2,6 +2,7 @@ var Base = require('mocha').reporters.Base
   , cursor = Base.cursor
   , color = Base.color
   , fs = require('fs')
+  , md5 = require('md5')
   , filename = process.env.MOCHA_FILE || 'mocha.json';
 
 exports = module.exports = BambooJSONReporter;
@@ -51,7 +52,11 @@ function BambooJSONReporter(runner, options) {
       , skipped: skipped.map(clean)
     };
 
-    fs.writeFileSync(filename, JSON.stringify(obj, null, 2), 'utf-8');
+    const output = JSON.stringify(obj, null, 2);
+    if (filename.indexOf('[hash]') !== -1) {
+      filePath = filePath.replace('[hash]', md5(output));
+    }
+    fs.writeFileSync(filename, output, 'utf-8');
   });
   runner.on('start', function() {
     if (fs.existsSync(filename)) {

--- a/lib/bamboo.js
+++ b/lib/bamboo.js
@@ -54,7 +54,7 @@ function BambooJSONReporter(runner, options) {
 
     const output = JSON.stringify(obj, null, 2);
     if (filename.indexOf('[hash]') !== -1) {
-      filePath = filePath.replace('[hash]', md5(output));
+      filename = filename.replace('[hash]', md5(output));
     }
     fs.writeFileSync(filename, output, 'utf-8');
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "mocha-bamboo-reporter",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://repo.forge.lmig.com/api/npm/npm/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://repo.forge.lmig.com/api/npm/npm/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://repo.forge.lmig.com/api/npm/npm/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://repo.forge.lmig.com/api/npm/npm/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   },
   "peerDependencies": {
     "mocha": ">=1.8.1"
+  },
+  "dependencies": {
+    "md5": "^2.2.1"
   }
 }


### PR DESCRIPTION
Using this package with Cypress, which generates a test report _per spec_.  This means that each succeeding spec will overwrite the test output from the previous test (see Cypress docs here: https://docs.cypress.io/guides/tooling/reporters.html#Report-per-spec).

This update allows the use of this reporter with Cypress and Bamboo.